### PR TITLE
Add Facility domain model and EF Core persistence with migration and seed

### DIFF
--- a/src/CoreEdificio.Domain/Entities/Facility.cs
+++ b/src/CoreEdificio.Domain/Entities/Facility.cs
@@ -1,0 +1,43 @@
+namespace CoreEdificio.Domain.Entities;
+
+public class Facility
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CommunityId { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public bool IsActive { get; set; } = true;
+    public int? Capacity { get; set; }
+    public FacilityChargingMode ChargingMode { get; set; }
+    public int RentAmountClp { get; set; }
+    public int DepositAmountClp { get; set; }
+    public bool RequiresApproval { get; set; }
+    public int SlotDurationMinutes { get; set; }
+    public int? MaxHoursPerBooking { get; set; }
+    public int? MaxBookingsPerMonthPerUnit { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(Name))
+            throw new InvalidOperationException("Facility name is required.");
+
+        if (SlotDurationMinutes <= 0)
+            throw new InvalidOperationException("Slot duration must be greater than zero.");
+
+        var requiresRent = ChargingMode is FacilityChargingMode.Paid or FacilityChargingMode.PaidAndDeposit;
+        var requiresDeposit = ChargingMode is FacilityChargingMode.Deposit or FacilityChargingMode.PaidAndDeposit;
+
+        if (requiresRent && RentAmountClp <= 0)
+            throw new InvalidOperationException("Rent amount must be greater than zero for paid facilities.");
+
+        if (requiresDeposit && DepositAmountClp <= 0)
+            throw new InvalidOperationException("Deposit amount must be greater than zero for deposit-based facilities.");
+
+        if (ChargingMode == FacilityChargingMode.Free)
+        {
+            if (RentAmountClp != 0 || DepositAmountClp != 0)
+                throw new InvalidOperationException("Free facilities must have zero rent and deposit amounts.");
+        }
+    }
+}

--- a/src/CoreEdificio.Domain/Entities/FacilityChargingMode.cs
+++ b/src/CoreEdificio.Domain/Entities/FacilityChargingMode.cs
@@ -1,0 +1,9 @@
+namespace CoreEdificio.Domain.Entities;
+
+public enum FacilityChargingMode
+{
+    Free,
+    Paid,
+    Deposit,
+    PaidAndDeposit
+}

--- a/src/CoreEdificio.Infrastructure/Identity/IdentitySeeder.cs
+++ b/src/CoreEdificio.Infrastructure/Identity/IdentitySeeder.cs
@@ -24,6 +24,39 @@ public static class IdentitySeeder
         var community = await db.Communities.FirstOrDefaultAsync();
         if (community == null) return;
 
+        if (!await db.Facilities.AnyAsync(f => f.CommunityId == community.Id))
+        {
+            db.Facilities.AddRange(
+                new CoreEdificio.Domain.Entities.Facility
+                {
+                    CommunityId = community.Id,
+                    Name = "Quincho",
+                    Description = "Espacio para asados y reuniones.",
+                    IsActive = true,
+                    ChargingMode = CoreEdificio.Domain.Entities.FacilityChargingMode.PaidAndDeposit,
+                    RentAmountClp = 30000,
+                    DepositAmountClp = 50000,
+                    RequiresApproval = true,
+                    SlotDurationMinutes = 60,
+                    CreatedAtUtc = DateTime.UtcNow
+                },
+                new CoreEdificio.Domain.Entities.Facility
+                {
+                    CommunityId = community.Id,
+                    Name = "Sala Reuniones",
+                    Description = "Espacio multiuso para reuniones.",
+                    IsActive = true,
+                    ChargingMode = CoreEdificio.Domain.Entities.FacilityChargingMode.Free,
+                    RentAmountClp = 0,
+                    DepositAmountClp = 0,
+                    RequiresApproval = false,
+                    SlotDurationMinutes = 60,
+                    CreatedAtUtc = DateTime.UtcNow
+                });
+
+            await db.SaveChangesAsync();
+        }
+
         var unit = await db.Units.FirstOrDefaultAsync();
         if (unit == null) return;
 

--- a/src/CoreEdificio.Infrastructure/Migrations/20260116120000_AddFacilities.Designer.cs
+++ b/src/CoreEdificio.Infrastructure/Migrations/20260116120000_AddFacilities.Designer.cs
@@ -4,6 +4,7 @@ using CoreEdificio.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CoreEdificio.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260116120000_AddFacilities")]
+    partial class AddFacilities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CoreEdificio.Infrastructure/Migrations/20260116120000_AddFacilities.cs
+++ b/src/CoreEdificio.Infrastructure/Migrations/20260116120000_AddFacilities.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoreEdificio.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFacilities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Facilities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CommunityId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    Capacity = table.Column<int>(type: "int", nullable: true),
+                    ChargingMode = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    RentAmountClp = table.Column<int>(type: "int", nullable: false),
+                    DepositAmountClp = table.Column<int>(type: "int", nullable: false),
+                    RequiresApproval = table.Column<bool>(type: "bit", nullable: false),
+                    SlotDurationMinutes = table.Column<int>(type: "int", nullable: false),
+                    MaxHoursPerBooking = table.Column<int>(type: "int", nullable: true),
+                    MaxBookingsPerMonthPerUnit = table.Column<int>(type: "int", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Facilities", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Facilities_CommunityId_Name",
+                table: "Facilities",
+                columns: new[] { "CommunityId", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Facilities");
+        }
+    }
+}

--- a/src/CoreEdificio.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/CoreEdificio.Infrastructure/Persistence/AppDbContext.cs
@@ -20,6 +20,7 @@ public class AppDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid
     public virtual DbSet<Payment> Payments { get; set; } = null!;
     public virtual DbSet<UserUnit> UserUnits { get; set; } = null!;
     public virtual DbSet<UnitComponent> UnitComponents { get; set; } = null!;
+    public virtual DbSet<Facility> Facilities { get; set; } = null!;
 
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -173,6 +174,28 @@ public class AppDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid
             b.HasIndex(x => new { x.CommunityId, x.UnitId });
             b.HasIndex(x => new { x.UnitId, x.Type, x.Code }).IsUnique();
             b.HasIndex(x => new { x.CommunityId, x.Type, x.Code }).IsUnique();
+        });
+
+        modelBuilder.Entity<Facility>(b =>
+        {
+            b.ToTable("Facilities");
+            b.HasKey(x => x.Id);
+
+            b.Property(x => x.CommunityId).IsRequired();
+            b.Property(x => x.Name).HasMaxLength(200).IsRequired();
+            b.Property(x => x.Description).HasMaxLength(500);
+            b.Property(x => x.IsActive).IsRequired();
+            b.Property(x => x.Capacity);
+            b.Property(x => x.ChargingMode).HasConversion<string>().HasMaxLength(20).IsRequired();
+            b.Property(x => x.RentAmountClp).IsRequired();
+            b.Property(x => x.DepositAmountClp).IsRequired();
+            b.Property(x => x.RequiresApproval).IsRequired();
+            b.Property(x => x.SlotDurationMinutes).IsRequired();
+            b.Property(x => x.MaxHoursPerBooking);
+            b.Property(x => x.MaxBookingsPerMonthPerUnit);
+            b.Property(x => x.CreatedAtUtc).IsRequired();
+
+            b.HasIndex(x => new { x.CommunityId, x.Name }).IsUnique();
         });
     }
 }


### PR DESCRIPTION
### Motivation
- Implementar el dominio base de espacios comunes (`Facility`) con soporte de modos de cobro opcional y reglas de validación.
- Preparar la persistencia para Facilities en la base de datos y evitar duplicados por comunidad/nombre.
- Proveer un seed mínimo para desarrollo (un espacio gratuito y uno pagado) sin exponer endpoints aún.

### Description
- Añadido enum `FacilityChargingMode` y la entidad `Facility` con los campos solicitados y método `Validate()` que aplica las reglas de negocio de cobro y duración de slot.
- Registrado `DbSet<Facility> Facilities` y mapeo en `AppDbContext` incluyendo almacenamiento del enum como `string`, campos requeridos y el índice único `(CommunityId, Name)`.
- Incluida migración `20260116120000_AddFacilities.cs` (y su `.Designer.cs`) y actualización de `AppDbContextModelSnapshot.cs` que crean la tabla `Facilities` con las columnas y el índice.
- Seed agregado en `IdentitySeeder` para insertar dos facilities de ejemplo (`Quincho` con `PaidAndDeposit` y `Sala Reuniones` como `Free`) si no existen para la comunidad seed.

### Testing
- Intenté generar/aplicar migración con `dotnet ef migrations add AddFacilities --project src/CoreEdificio.Infrastructure --startup-project src/CoreEdificio.Api` pero falló por falta de `dotnet` en el entorno de ejecución (no disponible).
- Intenté aplicar la migración con `dotnet ef database update --project src/CoreEdificio.Infrastructure --startup-project src/CoreEdificio.Api` pero también falló por la misma razón (entorno sin `dotnet`).
- No se ejecutaron pruebas automatizadas adicionales ni compilación en este entorno; los archivos de migración y cambios de código fueron añadidos y comiteados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f9501551083328a737c976a21f7a1)